### PR TITLE
Pkg alternative

### DIFF
--- a/en/hosting/freebsd/x-server-with-vnc/index.rst
+++ b/en/hosting/freebsd/x-server-with-vnc/index.rst
@@ -73,6 +73,7 @@ Alternatively, instead to build each port manually, it is possible to use pkg(8)
 Example using pkg(8) to install screen.
 
     ::
+
         # pkg install sysutils/screen
 
 Now its time to build all packages for X11. You can also install binary (precompiled) FreeBSD packages but its more fun to customize things (and one of the things which work very well under FreeBSD).

--- a/en/hosting/freebsd/x-server-with-vnc/index.rst
+++ b/en/hosting/freebsd/x-server-with-vnc/index.rst
@@ -62,7 +62,7 @@ This should take around 10 minutes.
 
 After having the Ports in place we install screen first ( https://www.gnu.org/software/screen/ ) which allows us to run interactive shells in multiple, virtual terminal windows andin case our network connection breaks down we can simply run "screen -r" to get the terminal back.
 You'll see a couple of dialogs asking configuration specific questions (simply hit the Enter key). Setting the environment variable BATCH=yes will disable these interactive prompts.
-Alternatively, instead to build each port manually, it is possible to use pkg(8) to install the pre-built binary of these ports. In case there is no need to tuning clfgas for compilers or any other tuning case, we encourage you to use pkg. 
+Alternatively, instead to build each port manually, it is possible to use pkg(8) to install the pre-built binary of these ports. In case there is no need to tuning cflags for compilers or any other tuning case, we encourage you to use pkg. 
 
     ::
 

--- a/en/hosting/freebsd/x-server-with-vnc/index.rst
+++ b/en/hosting/freebsd/x-server-with-vnc/index.rst
@@ -62,12 +62,18 @@ This should take around 10 minutes.
 
 After having the Ports in place we install screen first ( https://www.gnu.org/software/screen/ ) which allows us to run interactive shells in multiple, virtual terminal windows andin case our network connection breaks down we can simply run "screen -r" to get the terminal back.
 You'll see a couple of dialogs asking configuration specific questions (simply hit the Enter key). Setting the environment variable BATCH=yes will disable these interactive prompts.
+Alternatively, instead to build each port manually, it is possible to use pkg(8) to install the pre-built binary of these ports. In case there is no need to tuning clfgas for compilers or any other tuning case, we encourage you to use pkg. 
 
     ::
 
         $ cd /usr/ports/sysutils/screen
         $ make install
         $ screen
+
+Example using pkg(8) to install screen.
+
+    ::
+        # pkg install sysutils/screen
 
 Now its time to build all packages for X11. You can also install binary (precompiled) FreeBSD packages but its more fun to customize things (and one of the things which work very well under FreeBSD).
 We start by building and installing the virtual X11-server (xvfb), xkeyboard-config and Window Maker.


### PR DESCRIPTION
- Append to the article how users could alternatively use pkg(8) to install the pre-built package.